### PR TITLE
Simplify the config file path code and remove the x64 configuration

### DIFF
--- a/SC4MessageViewer.sln
+++ b/SC4MessageViewer.sln
@@ -7,18 +7,12 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SC4MessageViewer", "SC4Mess
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Debug|x64.ActiveCfg = Debug|x64
-		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Debug|x64.Build.0 = Debug|x64
 		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Debug|x86.ActiveCfg = Debug|Win32
 		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Debug|x86.Build.0 = Debug|Win32
-		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Release|x64.ActiveCfg = Release|x64
-		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Release|x64.Build.0 = Release|x64
 		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Release|x86.ActiveCfg = Release|Win32
 		{8FD5AE1F-8B2C-4341-B1FA-E1AAA78C4F60}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/SC4MessageViewer.vcxproj
+++ b/SC4MessageViewer.vcxproj
@@ -9,14 +9,6 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -39,19 +31,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -61,12 +40,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -93,36 +66,6 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>vendor/gzcom-dll/gzcom-dll/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/SC4MessageViewer.vcxproj
+++ b/SC4MessageViewer.vcxproj
@@ -77,7 +77,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>vendor/gzcom-dll/gzcom-dll/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>Default</LanguageStandard>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -93,6 +93,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>vendor/gzcom-dll/gzcom-dll/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -107,6 +108,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -121,6 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -258,8 +261,16 @@
     <None Include="message_viewer_config.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.ImplementationLibrary.1.0.231028.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
 </Project>

--- a/SC4MessageViewer.vcxproj.filters
+++ b/SC4MessageViewer.vcxproj.filters
@@ -391,5 +391,6 @@
     <None Include="message_viewer_config.ini">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.231028.1" targetFramework="native" />
+</packages>

--- a/src/cFileHelper.cpp
+++ b/src/cFileHelper.cpp
@@ -1,40 +1,19 @@
 #include "cFileHelper.h"
 
 #include <Windows.h>
+#include "wil/resource.h"
+#include "wil/filesystem.h"
 
-// Based off: https://stackoverflow.com/a/875264
-std::wstring cFileHelper::GetCurrentPath()
+std::filesystem::path cFileHelper::GetCurrentModuleDirectory()
 {
-    WCHAR buffer[MAX_PATH] = { 0 };
-    GetModuleFileName(NULL, buffer, MAX_PATH);
-    const std::wstring fullPath = std::wstring(buffer);
+    wil::unique_cotaskmem_string modulePath = wil::GetModuleFileNameW(wil::GetModuleInstanceHandle());
 
-    const std::wstring::size_type lastDirSeparatorPos = fullPath.find_last_of(L'\\/');
-    if (lastDirSeparatorPos != std::wstring::npos)
-    {
-        return fullPath.substr(0, lastDirSeparatorPos);
-    }
-    else
-    {
-        return fullPath;
-    }
+    std::filesystem::path temp(modulePath.get());
+
+    return temp.parent_path();
 }
 
-std::wstring cFileHelper::GetParentDirectory(std::wstring path)
-{
-    // Warning: We are going to make a lot of assumptions about the format of the path
-    // this works for us but will not be robust enough to be used in many other applications
-
-    // Strip any leading directory seperator 
-    if (path.back() == '\\')
-    {
-        path.erase(path.size() - 1, 1);
-    }
-
-    return path.substr(0, path.find_last_of('\\'));
-}
-
-bool cFileHelper::DoesFileExist(const std::wstring& path)
+bool cFileHelper::DoesFileExist(const std::filesystem::path& path)
 {
     const DWORD fileType = GetFileAttributes(path.c_str());
 

--- a/src/cFileHelper.h
+++ b/src/cFileHelper.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <string>
+#include <filesystem>
 
 class cFileHelper
 {
 public:
-	static std::wstring GetCurrentPath();
-	static std::wstring GetParentDirectory(std::wstring path);
-	static bool DoesFileExist(const std::wstring& path);
+	static std::filesystem::path GetCurrentModuleDirectory();
+	static bool DoesFileExist(const std::filesystem::path& path);
 };

--- a/src/cMessageLoggerCOMDirector.cpp
+++ b/src/cMessageLoggerCOMDirector.cpp
@@ -25,8 +25,7 @@ cMessageLoggerCOMDirector::cMessageLoggerCOMDirector()
 	}
 
 	// Try and read from the config file
-	// (When we use GetCurrentPath, we are retrieving the location of "SimCity 4.exe" so need to do some fiddling to get the plugin path)
-	const std::wstring configFilePath = cFileHelper::GetParentDirectory(cFileHelper::GetCurrentPath()) + L"\\" + L"Plugins" + L"\\" + CONFIG_FILE_NAME;
+	const std::filesystem::path configFilePath = cFileHelper::GetCurrentModuleDirectory().append(CONFIG_FILE_NAME);
 	if (cFileHelper::DoesFileExist(configFilePath) == false)
 	{
 		if (config.CreateDefault(configFilePath) == false)


### PR DESCRIPTION
The simplified config file path code also fixes a bug where the it would return an empty string for
module paths longer than 260 characters.
As SC4 is a 32-bit app, there is no need for a x64 build configuration.