### PR TITLE
Convert cConsoleLogger to a non-static class

### DIFF
--- a/src/cConfig.cpp
+++ b/src/cConfig.cpp
@@ -20,12 +20,15 @@ bool cConfig::CreateDefault(const std::wstring& sPath)
 	return true;
 }
 
-bool cConfig::Load(const std::wstring& sPath)
+bool cConfig::Load(const std::wstring& sPath, const cConsoleLogger* logger)
 {
 	std::ifstream fileStream(sPath.c_str());
 	if (fileStream.fail())
 	{
-		cConsoleLogger::LogMessage(eLogLevel::ERROR, "Failed to read config file\n");
+		if (logger)
+		{
+			logger->LogMessage(eLogLevel::ERROR, "Failed to read config file\n");
+		}
 		return false;
 	}
 
@@ -86,16 +89,20 @@ bool cConfig::Load(const std::wstring& sPath)
 		}
 	}
 
-	if (skippedProperties.size() > 0)
+	if (logger)
 	{
-		cConsoleLogger::LogMessage(eLogLevel::WARNING, "%d message ids could not be parsed:\n", skippedProperties.size());
-		for (const std::string& property : skippedProperties)
+		if (skippedProperties.size() > 0)
 		{
-			cConsoleLogger::Log("-> %s\n", property.c_str());
+			logger->LogMessage(eLogLevel::WARNING, "%d message ids could not be parsed:\n", skippedProperties.size());
+			for (const std::string& property : skippedProperties)
+			{
+				logger->Log("-> %s\n", property.c_str());
+			}
 		}
+
+		logger->LogMessage(eLogLevel::INFO, "Read %d message ids from config file\n", mMessageIds.size());
 	}
 
-	cConsoleLogger::LogMessage(eLogLevel::INFO, "Read %d message ids from config file\n", mMessageIds.size());
 	return true;
 }
 

--- a/src/cConfig.h
+++ b/src/cConfig.h
@@ -3,11 +3,13 @@
 #include <string>
 #include <map>
 
+#include "cConsoleLogger.h"
+
 class cConfig
 {
 public:
 	bool CreateDefault(const std::wstring& sPath);
-	bool Load(const std::wstring& sPath);
+	bool Load(const std::wstring& sPath, const cConsoleLogger* logger);
 
 	const std::map<uint32_t, std::string>& GetMessageIds() const { return mMessageIds; }
 

--- a/src/cConsoleLogger.cpp
+++ b/src/cConsoleLogger.cpp
@@ -1,22 +1,26 @@
 #include "cConsoleLogger.h"
 
-#include <cstdio>
-#include <iostream>
-#include <string>
+#include <stdio.h>
+#include <stdexcept>
 
-HANDLE cConsoleLogger::hConsoleOutput = NULL;
-CONSOLE_SCREEN_BUFFER_INFO cConsoleLogger::sbiConsoleInfo;
-WORD cConsoleLogger::wCurrentConsoleColor = 0;
+#include "wil/result.h"
 
-bool cConsoleLogger::Init()
+cConsoleLogger::cConsoleLogger() : hConsoleOutput(NULL), wCurrentConsoleColor(0)
 {
-    if (AllocConsole())
+    try
     {
-        // Redirect stdout to the newly created console.
-        freopen("CONOUT$", "w", stdout); // Use hConsoleOutput instead
+        THROW_LAST_ERROR_IF(!AllocConsole());
 
+        hConsoleOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+        THROW_LAST_ERROR_IF(hConsoleOutput == INVALID_HANDLE_VALUE);
+
+        if (!hConsoleOutput)
+        {
+            throw std::runtime_error("GetStdHandle returned a null handle.");
+        }
+
+        CONSOLE_SCREEN_BUFFER_INFO sbiConsoleInfo;
         // Get current console values if they haven't been set yet
-        hConsoleOutput = GetStdHandle(STD_OUTPUT_HANDLE); // TODO: Move to init
         if (GetConsoleScreenBufferInfo(hConsoleOutput, &sbiConsoleInfo))
         {
             wCurrentConsoleColor = sbiConsoleInfo.wAttributes;
@@ -26,53 +30,85 @@ bool cConsoleLogger::Init()
             // Default colour if we couldn't get the current console buffer
             wCurrentConsoleColor = 8;
         }
+    }
+    catch (const wil::ResultException& e)
+    {
+        throw std::runtime_error(e.what());
+    }
+}
 
-        return true;
+cConsoleLogger::~cConsoleLogger()
+{
+    // The OS will have closed the handle.
+    hConsoleOutput = NULL;
+}
+
+void cConsoleLogger::LogMessage(eLogLevel level, const char* format, ...) const
+{
+    if (!hConsoleOutput)
+    {
+        return;
     }
 
-    return false;
-}
-
-void cConsoleLogger::Teardown()
-{
-    CloseHandle(hConsoleOutput);
-    FreeConsole();
-}
-
-void cConsoleLogger::LogMessage(eLogLevel level, const char* format, ...)
-{
     if (wCurrentConsoleColor != level)
     {
         wCurrentConsoleColor = level;
         SetConsoleTextAttribute(hConsoleOutput, wCurrentConsoleColor);
     }
 
-    // Get current time
-    SYSTEMTIME st;
-    GetSystemTime(&st);
-
-    // Print time
-    printf("[%hu:%hu:%hu.%hu] [%s] ",
-        st.wHour,
-        st.wMinute,
-        st.wSecond,
-        st.wMilliseconds,
-        mLogLevelStrings.at(level).c_str()); // Should check this level exists in the map but yeah...
+    char formattedString[4096]{};
 
     // Fetch arguments and format them into output
     va_list args;
     va_start(args, format);
-    vfprintf(stdout, format, args);
+    int formattedStringCharCount = vsnprintf(formattedString, sizeof(formattedString), format, args);
     va_end(args);
+
+    if (formattedStringCharCount > 0)
+    {
+        char outputString[6144]{};
+
+        // Get current time
+        SYSTEMTIME st;
+        GetSystemTime(&st);
+
+        // Print the time, log level and message.
+        int outputStringCharCount = snprintf(outputString,
+                                             sizeof(outputString),
+                                             "[%hu:%hu:%hu.%hu] [%s] %s",
+                                             st.wHour,
+                                             st.wMinute,
+                                             st.wSecond,
+                                             st.wMilliseconds,
+                                             mLogLevelStrings.at(level).c_str(), // Should check this level exists in the map but yeah...
+                                             formattedString);
+        if (outputStringCharCount > 0)
+        {
+            WriteFile(hConsoleOutput, outputString, static_cast<DWORD>(outputStringCharCount), NULL, NULL);
+        }
+    }
 
     // Don't better resetting, for a small performance gain maybe
     //SetConsoleTextAttribute(hConsoleOutputHandle, wCurrentConsoleColor);
 }
 
-void cConsoleLogger::Log(const char* format, ...)
+
+void cConsoleLogger::Log(const char* format, ...) const
 {
+    if (!hConsoleOutput)
+    {
+        return;
+    }
+
+    char buffer[4096]{};
+
     va_list args;
     va_start(args, format);
-    vfprintf(stdout, format, args);
+    int charsWritten = vsnprintf(buffer, sizeof(buffer), format, args);
     va_end(args);
+
+    if (charsWritten > 0)
+    {
+        WriteFile(hConsoleOutput, buffer, static_cast<DWORD>(charsWritten), NULL, NULL);
+    }
 }

--- a/src/cConsoleLogger.h
+++ b/src/cConsoleLogger.h
@@ -29,13 +29,14 @@ const static std::map<WORD, std::string> mLogLevelStrings = {
 class cConsoleLogger
 {
 public:
-	static bool Init();
-	static void Teardown();
-    static void Log(const char* format, ...);
-    static void LogMessage(eLogLevel level, const char* format, ...);
+    cConsoleLogger();
+
+    ~cConsoleLogger();
+
+    void Log(const char* format, ...) const;
+    void LogMessage(eLogLevel level, const char* format, ...) const;
 
 private:
-    static HANDLE hConsoleOutput;
-    static CONSOLE_SCREEN_BUFFER_INFO sbiConsoleInfo;
-    static WORD wCurrentConsoleColor;
+    HANDLE hConsoleOutput;
+    mutable WORD wCurrentConsoleColor;
 };

--- a/src/cMessageLoggerCOMDirector.h
+++ b/src/cMessageLoggerCOMDirector.h
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <iostream>
+#include <memory>
 #include <thread>
 
 #include "include/cRZCOMDllDirector.h"
@@ -10,6 +11,7 @@
 #include "include/cIGZFrameWork.h"
 
 #include "cConfig.h"
+#include "cConsoleLogger.h"
 
 static const uint32_t kMessageLoggerDirectorId = 0xD81A8F98;
 
@@ -31,7 +33,7 @@ public:
 
 private:
 	cConfig config;
-	bool bSetup = false;
+	std::unique_ptr<cConsoleLogger> logger;
 };
 
 // DLL entry point


### PR DESCRIPTION
This ensures that Log and LogMessage are only called if the class initialization succeeded.

Throw an exception if AllocConsole or GetStdHandle fail. Changed the console writing code to use (v)snprintf and WriteFile.

Don't call CloseHandle of FreeConsole in the destructor, by the time it is called the OS will have already cleaned up those resources. This was causing the debugger to show an error as the process exited.