### PR TITLE
Rename the config file to SC4MessageViewer.ini

### DIFF
--- a/SC4MessageViewer.ini
+++ b/SC4MessageViewer.ini
@@ -2,6 +2,9 @@
 ; Configuration file for SC4MessageViewer
 ;###############################################
 
+[Admin]
+Enabled=true
+
 [setup]
 ConsoleLog = true
 FileLog = false

--- a/SC4MessageViewer.vcxproj
+++ b/SC4MessageViewer.vcxproj
@@ -204,7 +204,7 @@
     <ClCompile Include="vendor\gzcom-dll\gzcom-dll\src\cRZMessage2Standard.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="message_viewer_config.ini">
+    <None Include="SC4MessageViewer.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -1,10 +1,13 @@
 constexpr const char* PROGRAM_NAME = "SC4MessageViewer v1.0.2\n";
-constexpr const wchar_t* CONFIG_FILE_NAME = L"message_viewer_config.ini";
+constexpr const wchar_t* CONFIG_FILE_NAME = L"SC4MessageViewer.ini";
 
 constexpr const char* DEFAULT_CONFIG_FILE_CONTENTS =
 "; ###############################################\n\
 ; Configuration file for SC4MessageViewer\n\
 ; ###############################################\n\
+\n\
+[Admin]\n\
+Enabled=true\n\
 \n\
 [setup]\n\
 ConsoleLog = true\n\


### PR DESCRIPTION
This makes it clearer to user which plugin the file is associated with. It also allows users to disable the plugin by setting the Enabled value in the Admin section to false.